### PR TITLE
feat(gnu-utils): Fix paths to GNU utilities on MacOS and *BSD Platforms

### DIFF
--- a/bin/pyenv-users
+++ b/bin/pyenv-users
@@ -78,23 +78,41 @@ fi
 # The `links` are the symlink pathnames, `versions` are pyenv version strings,
 # and `venvs` are venv pathnames. Using parallel arrays since arrays-of-arrays
 # are a pain in bash. Keeping versions and venvs separate avoids needing awk.
-declare -a links versions venvs
+declare -a links versions venvs readlink realpath find
+
+if [ -n "$(type -p greadlink)" ]; then
+  readlink="$(type -p greadlink)"
+else
+  readlink="readlink"
+fi
+
+if [ -n "$(type -p grealpath)" ]; then
+  realpath="$(type -p grealpath)"
+else
+  realpath="realpath"
+fi
+
+if [ -n "$(type -p gfind)" ]; then
+  find="$(type -p gfind)"
+else
+  find="find"
+fi
 
 if [ -z "$PYENV_ROOT" ]; then
   PYENV_ROOT=$(pyenv root)
 fi
 
 # Collect all symlinks named `python` that point into $PYENV_ROOT
-cmd="readlink -f '{}' | grep -q ${PYENV_ROOT}"
+cmd="${readlink} -f '{}' | grep -q ${PYENV_ROOT}"
 while IFS= read -r -d $'\0' file; do
   links+=("$file")
-done < <(find -H "$DIR" -name "python" -type l -exec sh -c "$cmd" \; -print0)
+done < <(${find} -H "$DIR" -name "python" -type l -exec sh -c "$cmd" \; -print0)
 
 # Turn each link into a (version, venv) string pair
 regex="${PYENV_ROOT}/versions/(.+)/bin/(.+)"
 for link in "${links[@]}"; do
-  linkpath=$(realpath -s "$link")
-  target=$(readlink -f "$link")
+  linkpath=$(${realpath} -s "$link")
+  target=$(${readlink} -f "$link")
   [[ "$target" =~ $regex ]]
   version="${BASH_REMATCH[1]}"
   # Only capture links outside PYENV_ROOT or inside pyenv-virtualenv venvs

--- a/bin/pyenv-users
+++ b/bin/pyenv-users
@@ -78,7 +78,8 @@ fi
 # The `links` are the symlink pathnames, `versions` are pyenv version strings,
 # and `venvs` are venv pathnames. Using parallel arrays since arrays-of-arrays
 # are a pain in bash. Keeping versions and venvs separate avoids needing awk.
-declare -a links versions venvs readlink realpath find
+declare -a links versions venvs
+declare readlink realpath find
 
 if [ -n "$(type -p greadlink)" ]; then
   readlink="$(type -p greadlink)"


### PR DESCRIPTION
When using non-GNU based OSs, you usually use Ports (homebrew, macports, or ports on BSD(s)), and the GNU tool variants have `g` prepended.

Using the BSD versions of realpath for instance will return:
```
Bryans-MacBook-Pro:~ bhundven$ pyenv users ~
realpath: illegal option -- s
usage: realpath [-q] [path ...]
```

So override the tool usage with a variable that can point to the proper tool name.

Tested on my MacOS 15.2 MBP:
```
Bryans-MacBook-Pro:~ bhundven$ pyenv users ~
3.13.1  .pyenv/versions/3.13.1/envs/3.13.1-global
```